### PR TITLE
Use select instead of datepicker on census auth

### DIFF
--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -17,6 +17,24 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   validate :over_14
   validate :check_response
 
+  def self.from_params(params, additional_params = {})
+    instance = super(params, additional_params)
+
+    params_hash = hash_from(params)
+
+    if params_hash["date_of_birth(1i)"]
+      date = Date.civil(
+        params["date_of_birth(1i)"].to_i,
+        params["date_of_birth(2i)"].to_i,
+        params["date_of_birth(3i)"].to_i
+      )
+
+      instance.date_of_birth = date
+    end
+
+    instance
+  end
+
   # If you need to store any of the defined attributes in the authorization you
   # can do it here.
   #

--- a/app/views/census_authorization/_form.html.erb
+++ b/app/views/census_authorization/_form.html.erb
@@ -1,0 +1,13 @@
+<div class="field">
+  <%= form.text_field :document_number %>
+</div>
+
+<div class="field date">
+  <%= form.date_select :date_of_birth, start_year: 1900, end_year: 15.years.ago.year, default: 35.years.ago, prompt: { day: t(".date_select.day"), month: t(".date_select.month"), year: t(".date_select.year") } %>
+</div>
+
+<%= form.hidden_field :handler_name %>
+
+<div class="actions">
+  <%= form.submit t("authorize", scope: "decidim.authorizations.new"), class: "button expanded" %>
+</div>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -3,7 +3,13 @@ ca:
     attributes:
       census_authorization_handler:
         date_of_birth: Data de naixement
-        document_number: Número de document
+        document_number: Número de DNI
+  census_authorization:
+    form:
+      date_select:
+        day: Dia
+        month: Mes
+        year: Any
   census_authorization_handler:
     age_under_14: Has de ser major de 14 anys per validar-te
   decidim:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,23 +1,7 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  census_authorization:
+    form:
+      date_select:
+        day: Day
+        month: Month
+        year: Year

--- a/spec/features/authorizations_spec.rb
+++ b/spec/features/authorizations_spec.rb
@@ -5,24 +5,21 @@ require "spec_helper"
 describe "Authorizations", type: :feature, perform_enqueued: true do
   let(:organization) { create :organization, available_authorizations: authorizations }
   let(:authorizations) { ["CensusAuthorizationHandler"] }
+  let(:response) do
+    JSON.parse("{ \"res\": 1 }")
+  end
 
   # Selects a birth date that will not cause errors in the form: January 12, 1979.
   def fill_in_authorization_form
-    page.execute_script("$('#date_field_authorization_handler_date_of_birth').focus()")
-    page.find(".datepicker-dropdown .datepicker-days .date-switch").click
-    page.find(".datepicker-dropdown .datepicker-months .date-switch").click
-    page.find(".datepicker-dropdown .datepicker-years .prev").click
-    page.find(".datepicker-dropdown .datepicker-years .prev").click
-    page.find(".datepicker-dropdown .datepicker-years .prev").click
-    page.find(".datepicker-dropdown .year:first-child").click
-    page.find(".datepicker-dropdown .month:first-child").click
-    page.find(".datepicker-dropdown .day", text: "12").click
-    fill_in "Número de document", with: "12345678A"
+    fill_in "authorization_handler_document_number", with: "12345678A"
+    select "12", from: "authorization_handler_date_of_birth_3i"
+    select "January", from: "authorization_handler_date_of_birth_2i"
+    select "1979", from: "authorization_handler_date_of_birth_1i"
   end
 
   before do
     Decidim.authorization_handlers = [CensusAuthorizationHandler]
-    allow_any_instance_of(CensusAuthorizationHandler).to receive(:response).and_return(JSON.parse("{ \"res\": 1 }"))
+    allow_any_instance_of(CensusAuthorizationHandler).to receive(:response).and_return(response)
     switch_to_host(organization.host)
   end
 
@@ -45,6 +42,7 @@ describe "Authorizations", type: :feature, perform_enqueued: true do
         fill_in_authorization_form
         click_button "Send"
         expect(page).to have_content("successfully")
+        expect(page).to have_content("blabjekfha")
       end
 
       it "allows the user to skip it" do

--- a/spec/features/authorizations_spec.rb
+++ b/spec/features/authorizations_spec.rb
@@ -42,7 +42,6 @@ describe "Authorizations", type: :feature, perform_enqueued: true do
         fill_in_authorization_form
         click_button "Send"
         expect(page).to have_content("successfully")
-        expect(page).to have_content("blabjekfha")
       end
 
       it "allows the user to skip it" do


### PR DESCRIPTION
#### :tophat: What? Why?
Changes the datepicker to selects in the census authorization form.

#### :pushpin: Related Issues
- Fixes #28.

#### :camera: Screenshots (optional)
![Description](https://i.imgur.com/L4khIRk.png)
