### PR TITLE
Fix dates in virtus forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ ruby '2.4.2'
 gem "decidim", git: "https://github.com/decidim/decidim", branch: "master"
 gem "decidim-assemblies", git: "https://github.com/decidim/decidim", branch: "master"
 
+gem "virtus-multiparams"
+
 gem 'uglifier'
 gem 'faker'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -590,6 +590,8 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    virtus-multiparams (0.1.1)
+      virtus (~> 1.0)
     warden (1.2.7)
       rack (>= 1.0)
     webmock (3.1.0)
@@ -629,6 +631,7 @@ DEPENDENCIES
   spring-watcher-listen
   tzinfo-data
   uglifier
+  virtus-multiparams
 
 RUBY VERSION
    ruby 2.4.2p198

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -6,6 +6,7 @@ require "digest/md5"
 # This class performs a check against the official census database in order
 # to verify the citizen's residence.
 class CensusAuthorizationHandler < Decidim::AuthorizationHandler
+  include Virtus::Multiparams
   include ActionView::Helpers::SanitizeHelper
 
   attribute :date_of_birth, Date
@@ -16,24 +17,6 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
 
   validate :over_14
   validate :check_response
-
-  def self.from_params(params, additional_params = {})
-    instance = super(params, additional_params)
-
-    params_hash = hash_from(params)
-
-    if params_hash["date_of_birth(1i)"]
-      date = Date.civil(
-        params["date_of_birth(1i)"].to_i,
-        params["date_of_birth(2i)"].to_i,
-        params["date_of_birth(3i)"].to_i
-      )
-
-      instance.date_of_birth = date
-    end
-
-    instance
-  end
 
   # If you need to store any of the defined attributes in the authorization you
   # can do it here.


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes dates not being correctly coerced in Virtus forms (only when impersonating) by using the [virtus-multiparams](https://github.com/sj26/virtus-multiparams) gem. Should probably be included in `decidim-core`.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/qq0scfSq7VRfy/giphy.gif)
