### PR TITLE
Lock geocoder version to 1.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'virtus-multiparams'
 gem 'faker'
 gem 'puma'
 gem 'uglifier'
+gem 'geocoder', '1.5.2'
 
 group :development, :test do
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,7 +411,7 @@ GEM
       activesupport (>= 4.1, < 6.0)
       railties (>= 4.1, < 6.0)
       tzinfo (~> 1.2, >= 1.2.2)
-    geocoder (1.6.2)
+    geocoder (1.5.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     graphiql-rails (1.4.11)
@@ -785,6 +785,7 @@ DEPENDENCIES
   excon (>= 0.71.0)
   faker
   fog-aws
+  geocoder (= 1.5.2)
   listen
   lograge
   newrelic_rpm


### PR DESCRIPTION
#### :tophat: What? Why?
Lock Geocoder version in order to be able to use old API keys.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Subtask 1
- [ ] Subtask 2

### :camera: Screenshots (optional)

#### :ghost: GIF
