### PR TITLE
Add dummy geocoder api key for dev and test environments

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,10 +32,7 @@
       "description": "Username for a custom CensusAuthenticationHandler, if needed",
       "required": false
     },
-    "HERE_APP_ID": {
-      "required": false
-    },
-    "HERE_APP_CODE": {
+    "HERE_API_KEY": {
       "required": false
     },
     "HEROKU_APP_NAME": {

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -34,7 +34,7 @@ default: &default
       client_id: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_ID"] %>
       client_secret: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_SECRET"] %>
   geocoder:
-    here_api_key: <%= ENV["GEOCODER_API_KEY"] %>
+    here_api_key: <%= ENV["HERE_API_KEY"] %>
 
 development:
   <<: *default

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -39,7 +39,8 @@ default: &default
 development:
   <<: *default
   secret_key_base: 86be19ea07f7ddbb51952d156c1436e4e8594d9c5c7c878208e2ca79215ff61245011d8e6be4add436207b327d71555a0b3dc17a5f1897fbf4a37df9529efb66
-
+  geocoder:
+    here_api_key: 1234123412341234
 test:
   <<: *default
   secret_key_base: 79f3b6fc843e46e969d41805bd6744338235b1b45458e380f1e12e9b813034a30dda97d541895d83af0e3c9c0ee73c96995f4d7e9d7e480268904fbcdacf1204
@@ -50,6 +51,8 @@ test:
       enabled: true
     google_oauth2:
       enabled: true
+  geocoder:
+    here_api_key: 1234123412341234
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.


### PR DESCRIPTION
#### :tophat: What? Why?
Add dummy geocoder api key for dev and test environments and rename geocoder env variable.
