### PR TITLE
Strip trailing spaces from WS response

### DIFF
--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -31,8 +31,8 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   # it's created, and available though authorization.metadata
   def metadata
     {
-      district_council: response["consellBarri"],
-      district: response["barri"],
+      district_council: response["consellBarri"]&.strip,
+      district: response["barri"]&.strip,
     }
   end
 

--- a/spec/services/census_authorization_handler_spec.rb
+++ b/spec/services/census_authorization_handler_spec.rb
@@ -70,7 +70,7 @@ describe CensusAuthorizationHandler do
     before do
       allow(handler)
         .to receive(:response)
-        .and_return(JSON.parse("{ \"res\": 1, \"barri\":\"2\",\"consellBarri\":\"1\" }"))
+        .and_return(JSON.parse("{ \"res\": 1, \"barri\":\" 2 \",\"consellBarri\":\" 1 \" }"))
     end
 
     it_behaves_like "an authorization handler"

--- a/spec/services/census_authorization_handler_spec.rb
+++ b/spec/services/census_authorization_handler_spec.rb
@@ -70,6 +70,7 @@ describe CensusAuthorizationHandler do
     before do
       allow(handler)
         .to receive(:response)
+        # the Webservice returns values with some trailing spaces
         .and_return(JSON.parse("{ \"res\": 1, \"barri\":\" 2 \",\"consellBarri\":\" 1 \" }"))
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The census WS responds with trailing blank spaces in the values of the "barri" and "consellBarri".
This PR strips the values responded by the webservice  before assigning them to the `Authorization.metadata`.
