### PR TITLE
Add new queue to sidekiq

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,8 @@
 :concurrency: 5
 :queues:
   - default
-  - mailers
-  - newsletter
-  - metrics
   - events
+  - mailers
+  - metrics
+  - newsletter
+  - exports


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds a new Sidekiq queue that was introduced in Decidim to manage exports
