### PR TITLE
Add public option to amazon storage service

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,6 +13,7 @@ amazon:
   secret_access_key: <%= Rails.application.secrets.aws_secret_access_key %>
   region: eu-west-1
   bucket: <%= Rails.application.secrets.aws_bucket %>
+  public: true
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
#### :tophat: What? Why?

This PR changes the amazon service to provide public access and avoids the generation of single use URLs to the attachments stored there.