### PR TITLE
Revert public option

### DIFF
--- a/config/initializers/aws_sdk_service.rb
+++ b/config/initializers/aws_sdk_service.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "aws-sdk-s3"
+require "active_storage/client_service_initialization_overrides"
+
+Aws::S3::Resource.class_eval do
+  prepend ActiveStorage::ClientServiceInitializationOverrides
+end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,6 +13,7 @@ amazon:
   secret_access_key: <%= Rails.application.secrets.aws_secret_access_key %>
   region: eu-west-1
   bucket: <%= Rails.application.secrets.aws_bucket %>
+  public: true
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,7 +13,6 @@ amazon:
   secret_access_key: <%= Rails.application.secrets.aws_secret_access_key %>
   region: eu-west-1
   bucket: <%= Rails.application.secrets.aws_bucket %>
-  public: true
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:

--- a/lib/active_storage/client_service_initialization_overrides.rb
+++ b/lib/active_storage/client_service_initialization_overrides.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module ActiveStorage
+  module ClientServiceInitializationOverrides
+    extend ActiveSupport::Concern
+
+    def initialize(options = {})
+      opts = options.dup.except(:public)
+      @client = options[:client] || Aws::S3::Client.new(opts)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR avoids errors initializing S3 service when configured with `public: true` setting

