### PR TITLE
Add Rack::Attack configuration to application config file

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,3 +19,11 @@ module DecidimSantCugat
     config.i18n.default_locale = :ca
   end
 end
+
+Decidim.configure do |config|
+  # Max requests in a time period to prevent DoS attacks. Only applied on production.
+  config.throttling_max_requests = 1000
+
+  # Time window in which the throttling is applied.
+  # config.throttling_period = 1.minute
+end


### PR DESCRIPTION
#### :tophat: What? Why?

There is a limit to requests added by Rack::Attack, used by elections module which affects to the whole application. The default limit is 100 and if the application receives more than 100 requests (it can happen in a list of more than 100 participatory processes with images) it locks for a while

#### :pushpin: Related Issues
- Related to https://github.com/PopulateTools/issues/issues/1473
