### PR TITLE
Fix Faraday syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ public/uploads
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+# Env vars
+.rbenv-vars

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -62,8 +62,9 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
 
     return @response if defined?(@response)
 
-    connection = Faraday.new Rails.application.secrets.dig(:census, :url), ssl: { verify: false }
-    connection.basic_auth(Rails.application.secrets.dig(:census, :auth_user), Rails.application.secrets.dig(:census, :auth_pass))
+    connection = Faraday.new(Rails.application.secrets.dig(:census, :url), ssl: { verify: false }) do |builder|
+      builder.request :authorization, :basic, Rails.application.secrets.dig(:census, :auth_user), Rails.application.secrets.dig(:census, :auth_pass)
+    end
 
     response = connection.get do |request|
       request.params = request_params


### PR DESCRIPTION
#### :tophat: What? Why?

This PR updates census API call because Faraday was updated to 2.x and the way to include HTTP Auth in the requests changed (see [docs](https://lostisland.github.io/faraday/middleware/authentication)).
