### PR TITLE
Configure 0 days access

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -5,6 +5,8 @@ Decidim.configure do |config|
   config.mailer_sender    = "participacio@santcugat.cat"
   config.maximum_attachment_size = 100.megabytes
 
+  config.unconfirmed_access_for = 0.days
+
   # Uncomment this lines to set your preferred locales
   config.available_locales = %i{ca}
   config.default_locale = :ca


### PR DESCRIPTION
#### :tophat: What? Why?

This PR activates the setting of access without confirmation email to 0 day ([docs](https://docs.decidim.org/en/configure/initializer/#_unconfirmed_access_for_users))
