### PR TITLE
Disable login modal

### DIFF
--- a/app/views/decidim/shared/_disabled_login_modal.html.erb
+++ b/app/views/decidim/shared/_disabled_login_modal.html.erb
@@ -1,3 +1,4 @@
+<% #Disabled login modal now the process has finished %>
 <% ppp = ParticipatoryProcessPicker2022.new(nil) %>
 
 <div class="reveal two_columns" id="loginModal" data-reveal>


### PR DESCRIPTION
#### :tophat: What? Why?

This PR disables the overwritten modal. When the participatory process is enabled it should be enabled too