### PR TITLE
Ignore actions in AppSignal

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -11,6 +11,10 @@ default: &defaults
     - ActiveStorage::FileNotFoundError
   enable_frontend_error_catching: true
   enable_gc_instrumentation: true
+  ignore_actions:
+    - "LinksController#new"
+    - "ActiveStorage::BlobsController#show"
+    - "ActiveStorage::RepresentationsController#show"
 
 development:
   <<: *defaults


### PR DESCRIPTION
This PR ignores some actions from AppSignal:

- ActiveStorage controllers
- LinksController

