### PR TITLE
Add Aptfile

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,4 @@
+p7zip
+xfonts-base
+xfonts-75dpi
+https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds `Aptfile` configuration file to be used by apt buildpack
