### PR TITLE
Remove personalized devise failure user translation

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -50,7 +50,3 @@ ca:
         district_councils:
           one: La participació està restringida a les persones adscrites al consell de barri %{district_concils}.
           other: 'La participació està restringida a les persones adscrites a algun dels següents consells de barri: %{district_councils}.'
-  devise:
-    failure:
-      user:
-        invalid: Segons el cens, les teves dades no són correctes o no compleixes els requisits per participar.


### PR DESCRIPTION
#### :tophat: What? Why?

This PR recovers the default wrong email/password failure message provided by devise

The change can be reviewed in https://decidim-sant-cugat.populate.tools/users/sign_in

#### :pushpin: Related Issues
- Fixes PopulateTools/issues#2065

#### :clipboard: Subtasks
- [x] Subtask 1
- [ ] Subtask 2

### :camera: Screenshots (optional)
![Description](URL)

#### :ghost: GIF
![]()
