### PR TITLE
Use Rails 6.1 default in application configuration

### DIFF
--- a/app/controllers/decidim/participatory_process_picker_controller.rb
+++ b/app/controllers/decidim/participatory_process_picker_controller.rb
@@ -1,7 +1,7 @@
 module Decidim
   class ParticipatoryProcessPickerController < DecidimController
     def redirect
-      ppp = ParticipatoryProcessPicker2022.new(current_user)
+      ppp = ::ParticipatoryProcessPicker2022.new(current_user)
       redirect_to ppp.process_url and return false
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,13 +10,16 @@ Bundler.require(*Rails.groups)
 
 module DecidimSantCugat
   class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+    # Initialize configuration defaults for originally generated Rails version.
+    config.load_defaults 6.1
 
     # Locales
     config.i18n.available_locales = %w(ca)
     config.i18n.default_locale = :ca
+
+    # Settings in config/environments/* take precedence over those specified here.
+    # Application configuration should go into files in config/initializers
+    # -- all .rb files in that directory are automatically loaded.
   end
 end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes errors related with old zeitwerk loading by changing the application configuration defaults to 6.1

#### :pushpin: Related Issues
- Related to decidim/decidim#13041

#### :clipboard: Subtasks

The result of merging the PR can be reviewed in staging as admin: https://decidim-sant-cugat.populate.tools/admin/participatory_processes/centreoest/components/407/manage/

In production: https://decidim.santcugat.cat/admin/participatory_processes/centreoest/components/407/manage/
![image](https://github.com/user-attachments/assets/7e4de193-35fd-48c9-8f85-3e70f23f7fe5)



### :camera: Screenshots (optional)
![Description](URL)

#### :ghost: GIF
![]()
